### PR TITLE
Issue #27 All runtime function names use __, not .

### DIFF
--- a/Specifications/QIR/Classical-Runtime.md
+++ b/Specifications/QIR/Classical-Runtime.md
@@ -13,16 +13,16 @@ released when no longer necessary.
 We define the following functions for allocating and releasing heap memory,
 They should provide the same behavior as the standard C library functions malloc and free.
 
-| Function              | Signature   | Description |
-|-----------------------|-------------|-------------|
-| quantum.rt.heap_alloc | `i8*(i32)`  | Allocate a block of memory on the heap. |
-| quantum.rt.heap_free  | `void(i8*)` | Release a block of allocated heap memory. |
+| Function                  | Signature   | Description |
+|---------------------------|-------------|-------------|
+| __quantum__rt__heap_alloc | `i8*(i32)`  | Allocate a block of memory on the heap. |
+| __quantum__rt__heap_free  | `void(i8*)` | Release a block of allocated heap memory. |
 
 ### Termination
 
-| Function              | Signature         | Description |
-|-----------------------|-------------------|-------------|
-| quantum.rt.fail       | `void(%String*)`  | Fail the computation with the given error message. |
+| Function                  | Signature         | Description |
+|---------------------------|-------------------|-------------|
+| __quantum__rt__fail       | `void(%String*)`  | Fail the computation with the given error message. |
 
 ---
 _[Back to index](README.md)_

--- a/Specifications/QIR/Code-Generation.md
+++ b/Specifications/QIR/Code-Generation.md
@@ -7,7 +7,7 @@ from a simple rewrite of basic intrinsics to target machine code:
   garbage collection, and thus carefully tracks stack versus heap allocation
   and reference counting for heap-allocated structures. A runtime that provides
   full garbage collection may wish to remove the reference count field from several
-  intermediate representation structures and elide calls to `quantum.rt.free`
+  intermediate representation structures and elide calls to `__quantum__rt__free`
   and the various `unreference` functions.
 - Many types are defined as pointers to opaque structures. The code generator
   will need to either provide a concrete realization of the structure or replace

--- a/Specifications/QIR/Quantum-Runtime.md
+++ b/Specifications/QIR/Quantum-Runtime.md
@@ -11,12 +11,12 @@ that may be used by language-specific compilers.
 
 We define the following functions for managing qubits:
 
-| Function                        | Signature       | Description |
-|---------------------------------|-----------------|-------------|
-| quantum.rt.qubit_allocate       | `%Qubit*()`     | Allocates a single qubit. |
-| quantum.rt.qubit_allocate_array | `%Array*(i64)`  | Allocates an array of qubits. |
-| quantum.rt.qubit_release        | `void(%Qubit*)` | Release a single qubit. |
-| quantum.rt.qubit_release_array  | `void(%Array*)` | Release an array of qubits. |
+| Function                            | Signature       | Description |
+|-------------------------------------|-----------------|-------------|
+| __quantum__rt__qubit_allocate       | `%Qubit*()`     | Allocates a single qubit. |
+| __quantum__rt__qubit_allocate_array | `%Array*(i64)`  | Allocates an array of qubits. |
+| __quantum__rt__qubit_release        | `void(%Qubit*)` | Release a single qubit. |
+| __quantum__rt__qubit_release_array  | `void(%Array*)` | Release an array of qubits. |
 
 Allocated qubits are not guaranteed to be in any particular state.
 If a language guarantees that allocated qubits will be in a specific state, the compiler
@@ -25,12 +25,12 @@ Qubits should be unentangled -- measured out -- before they are released.
 
 If borrowing qubits is supported, then the following runtime functions should also be provided:
 
-| Function                        | Signature       | Description |
-|---------------------------------|-----------------|-------------|
-| quantum.rt.qubit_borrow         | `%Qubit*()`     | Borrow a single qubit. |
-| quantum.rt.qubit_borrow_array   | `%Array*(i64)`  | Borrow an array of qubits. |
-| quantum.rt.qubit_return         | `void(%Qubit*)` | Return a borrowed qubit. |
-| quantum.rt.qubit_return_array   | `void(%Array*)` | Return an array of borrowed qubits. |
+| Function                            | Signature       | Description |
+|-------------------------------------|-----------------|-------------|
+| __quantum__rt__qubit_borrow         | `%Qubit*()`     | Borrow a single qubit. |
+| __quantum__rt__qubit_borrow_array   | `%Array*(i64)`  | Borrow an array of qubits. |
+| __quantum__rt__qubit_return         | `void(%Qubit*)` | Return a borrowed qubit. |
+| __quantum__rt__qubit_return_array   | `void(%Array*)` | Return an array of borrowed qubits. |
 
 Borrowing qubits means supplying qubits that are guaranteed not to be otherwise
 accessed while they are borrowed.


### PR DESCRIPTION
Fixes #27 