### PR TITLE
Fix links replacement script to handle /tree/ links

### DIFF
--- a/Specifications/sync-script/replace_links.py
+++ b/Specifications/sync-script/replace_links.py
@@ -39,10 +39,13 @@ def links_to_xrefs(source_dir, map_link_to_uid):
             for line in text:
                 for url in map_link_to_uid:
                     uid = map_link_to_uid[url]
-                    full_url = 'https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/'+url
+                    # Handle both /blob/ and /tree/ links
+                    full_blob_url = 'https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/'+url
+                    full_tree_url = 'https://github.com/microsoft/qsharp-language/tree/main/Specifications/Language/'+url
                     full_uid = 'xref:'+ uid
-                    line = line.replace(full_url, full_uid)
+                    line = line.replace(full_blob_url, full_uid)
                     line = line.replace('← [Back to Index](https://github.com/microsoft/qsharp-language/tree/main/Specifications/Language#index)','')
+                    line = line.replace(full_tree_url, full_uid)
                 new_text.append(line)
         with open(source_dir + path, "wt", encoding='utf-8') as f:
             for line in new_text:


### PR DESCRIPTION
Currently the script handles only links of the form `https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/`, but the documentation also contains links with `/tree/` instead of `/blob/` which are left unchanged. 

This means that on the docs website part of the links point to other pages on the same website and part of the links point to this GitHub repo (for example, the link "example program" on [this page](https://docs.microsoft.com/en-us/quantum/user-guide/language/programstructure/callabledeclarations) or type links [here](https://docs.microsoft.com/en-us/quantum/user-guide/language/expressions/valueliterals)). 

It makes sense to unify the behavior for links that are included in the uid mapping.