### PR TITLE
Adding example of item access operator `::`

### DIFF
--- a/Specifications/Language/3_Expressions/ItemAccessExpressions.md
+++ b/Specifications/Language/3_Expressions/ItemAccessExpressions.md
@@ -37,7 +37,17 @@ The contained items can be accessed via their name or by deconstruction, illustr
     let im = complex::Imaginary;  // item access via name
 ```
 
-The item access operator (`::`) retrieves named items.
+The item access operator (`::`) retrieves named items. For example, it can be used to unpack a newtype operation parameter in a neater way than with individual item extraction: 
+
+```qsharp
+newtype TwoBitString = (bit1: String, bit2: String);
+
+operation Str(bits: TwoBitString):String {
+    let b1= bits::bit1;
+    let b2 = bits::bit2;
+    return b1+b2;
+}
+```
 While named items can be accessed by their name or via deconstruction, anonymous items can only be accessed by the latter. Since deconstruction relies on all of the contained items, the usage anonymous items is discourage when these items need to be accessed outside the compilation unit in which the type is defined. 
 
 Access via deconstruction makes use of the unwrap operator (`!`). That operator will return a tuple of all contained items, where the shape of the tuple matches the one defined in the declaration, and a single item tuple is equivalent to the item itself (see [this section](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/4_TypeSystem/SingletonTupleEquivalence.md#singleton-tuple-equivalence)).  

--- a/Specifications/Language/3_Expressions/ItemAccessExpressions.md
+++ b/Specifications/Language/3_Expressions/ItemAccessExpressions.md
@@ -42,10 +42,10 @@ The item access operator (`::`) retrieves named items. For example, it can be us
 ```qsharp
 newtype TwoBitString = (bit1: String, bit2: String);
 
-operation Str(bits: TwoBitString):String {
-    let b1= bits::bit1;
+operation Str(bits : TwoBitString) : String {
+    let b1 = bits::bit1;
     let b2 = bits::bit2;
-    return b1+b2;
+    return b1 + b2;
 }
 ```
 While named items can be accessed by their name or via deconstruction, anonymous items can only be accessed by the latter. Since deconstruction relies on all of the contained items, the usage anonymous items is discourage when these items need to be accessed outside the compilation unit in which the type is defined. 

--- a/Specifications/Language/3_Expressions/ItemAccessExpressions.md
+++ b/Specifications/Language/3_Expressions/ItemAccessExpressions.md
@@ -37,7 +37,7 @@ The contained items can be accessed via their name or by deconstruction, illustr
     let im = complex::Imaginary;  // item access via name
 ```
 
-The item access operator (`::`) retrieves named items. For example, it can be used to unpack a newtype operation parameter in a neater way than with individual item extraction: 
+The item access operator (`::`) retrieves named items, as illustrated by the following example:
 
 ```qsharp
 newtype TwoStrings = (str1: String, str2: String);

--- a/Specifications/Language/3_Expressions/ItemAccessExpressions.md
+++ b/Specifications/Language/3_Expressions/ItemAccessExpressions.md
@@ -40,12 +40,12 @@ The contained items can be accessed via their name or by deconstruction, illustr
 The item access operator (`::`) retrieves named items. For example, it can be used to unpack a newtype operation parameter in a neater way than with individual item extraction: 
 
 ```qsharp
-newtype TwoBitString = (bit1: String, bit2: String);
+newtype TwoStrings = (str1: String, str2: String);
 
-operation Str(bits : TwoBitString) : String {
-    let b1 = bits::bit1;
-    let b2 = bits::bit2;
-    return b1 + b2;
+operation LinkTwoStrings(str : TwoStrings) : String {
+    let s1 = str::str1;
+    let s2 = str::str2:
+    return s1 + s2;
 }
 ```
 While named items can be accessed by their name or via deconstruction, anonymous items can only be accessed by the latter. Since deconstruction relies on all of the contained items, the usage anonymous items is discourage when these items need to be accessed outside the compilation unit in which the type is defined. 


### PR DESCRIPTION
This closes [#323](https://github.com/MicrosoftDocs/quantum-docs/issues/323)
