### PR TITLE
Fix pipe character formatting

### DIFF
--- a/Specifications/Language/3_Expressions/PrecedenceAndAssociativity.md
+++ b/Specifications/Language/3_Expressions/PrecedenceAndAssociativity.md
@@ -12,10 +12,10 @@ Additional modifiers and combinators are listed further below and bind tighter t
 | --- | --- | --- | --- | --- |
 | [copy-and-update operator](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/CopyAndUpdateExpressions.md#copy-and-update-expressions) | `w/` `<-` | ternary | left  | 1  |
 | [range operator](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/ValueLiterals.md#range-literals) | `..` | infix | left | 2 |
-| [conditional operator](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/ConditionalExpressions.md#conditional-expressions) | `?` `\|` | ternary | right | 5 |
+| [conditional operator](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/ConditionalExpressions.md#conditional-expressions) | <code>? &vert;</code> | ternary | right | 5 |
 | [logical OR](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/LogicalExpressions.md#logical-expressions) | `or` | infix | left | 10 |
 | [logical AND](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/LogicalExpressions.md#logical-expressions) | `and` | infix | left | 11 |
-| [bitwise OR](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/BitwiseExpressions.md#bitwise-expressions) | `\|\|\|` | infix | left | 12 |
+| [bitwise OR](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/BitwiseExpressions.md#bitwise-expressions) | <code>&vert;&vert;&vert;</code> | infix | left | 12 |
 | [bitwise XOR](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/BitwiseExpressions.md#bitwise-expressions) | `^^^` | infix | left | 13 |
 | [bitwise AND](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/BitwiseExpressions.md#bitwise-expressions) | `&&&` | infix | left | 14 |
 | [equality](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/ComparativeExpressions.md#equality-comparison) | `==` | infix | left | 20 |


### PR DESCRIPTION
@tcNickolas - This should fix the pipe rendering error from [issue #352](https://github.com/MicrosoftDocs/quantum-docs/issues/352). 
The markdown code ticks, \` \`, aren't needed - the html \<code\> tag formats the characters the same way in GitHub and in the docs build. 