### PR TITLE
Misc edits

### DIFF
--- a/Specifications/Language/2_Statements/ConditionalBranching.md
+++ b/Specifications/Language/2_Statements/ConditionalBranching.md
@@ -33,7 +33,7 @@ else {
 
 You can also express simple branching in the form of a [conditional expression](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/ConditionalExpressions.md#conditional-expressions).
 
-## *Target-specific restrictions*
+## Target-specific restrictions
 
 The tight integration between control-flow constructs and quantum computations poses a challenge for current quantum hardware. Certain quantum processors do not support branching based on measurement outcomes. As such, comparison for values of type `Result` will always result in a compilation error for Q# programs that are targeted to run on such hardware. 
 

--- a/Specifications/Language/3_Expressions/ComparativeExpressions.md
+++ b/Specifications/Language/3_Expressions/ComparativeExpressions.md
@@ -10,7 +10,7 @@ Equality comparisons for `Double` values may be misleading due to rounding effec
 For instance, the following comparison evaluates to `false` due to rounding errors: `49.0 * (1.0/49.0) == 1.0`.
 
 >[!NOTE]
->In the future, qsharp may support the comparisons of ranges, as well as arrays, tuples, and user-defined types provided their items support comparison. As for all types, the comparison would be by value, meaning two values are considered equal if all of their items are. For values of user-defined type, their type also needs to match. Future support for the comparison of values of type `Range` follows the same logic; they should be equal as long as they produce the same sequence of integers, meaning the two ranges 
+>In the future, Q# may support the comparisons of ranges, as well as arrays, tuples, and user-defined types provided their items support comparison. As for all types, the comparison would be by value, meaning two values are considered equal if all of their items are. For values of user-defined type, their type also needs to match. Future support for the comparison of values of type `Range` follows the same logic; they should be equal as long as they produce the same sequence of integers, meaning the two ranges 
 >```qsharp
 >    let r1 = 0..2..5; // generates the sequence 0,2,4
 >    let r2 = 0..2..4; // generates the sequence 0,2,4

--- a/Specifications/Language/README.md
+++ b/Specifications/Language/README.md
@@ -45,11 +45,11 @@ Q# implements programs in terms of statements and expressions, much like classic
         1. [Arithmetic Expressions](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/ArithmeticExpressions.md#arithmetic-expressions)
         1. [Concatenations](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/Concatentation.md#concatenation)
     1. [Modifiers \& Combinators](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/PrecedenceAndAssociativity.md#modifiers-and-combinators)
-        1. [Closures](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/Closures.md)
         1. [Functor Application](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/FunctorApplication.md#functor-application)
         1. [Item Access Expressions](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/ItemAccessExpressions.md#item-access)
     1. [Contextual Expressions](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/ContextualExpressions.md#contextual-and-omitted-expressions)
     1. [Value Literals](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/ValueLiterals.md#literals) \& [Default Values](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/ValueLiterals.md#default-values)
+    1. [Closures](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/Closures.md)
     1. [Identifiers](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/3_Expressions/Identifiers.md#identifiers)
 
 


### PR DESCRIPTION
While reading the (in-progress) PDF version of the spec (#153), I noticed some issues which this PR corrects.

A note about the proposed change for the Closures section. When it was only about partial applications, it was probably suitable under "Modifiers & Combinators", but now with the addition of lambda expressions, it seems better to include it as a separate section under Expressions.

For formatting of target-specific, see https://github.com/microsoft/qsharp-language/pull/92#discussion_r932235328