### PR TITLE
Add citation file

### DIFF
--- a/CITATIONS.bib
+++ b/CITATIONS.bib
@@ -1,0 +1,17 @@
+BibTeX:
+
+@manual{QsSpec2020,
+  title         = {Q\# {Language Specification}},
+  author        = {Microsoft},
+  year          = {2020},
+  url           = {https://github.com/microsoft/qsharp-language/tree/main/Specifications/Language#q-language},
+}
+
+BiBLaTeX:
+
+@manual{QsSpec2020,
+  title         = {Q\# {Language Specification}},
+  organization  = {Microsoft},
+  date          = {2020},
+  url           = {https://github.com/microsoft/qsharp-language/tree/main/Specifications/Language#q-language}
+}


### PR DESCRIPTION
Unsure if one should point to the precise URL with the anchor `#q-language` as I have done in the URL field. Suggestions welcome.

(also added [an entry](https://quantumpl.github.io/bib/publication/QsSpec2020/) in the [QPL Bib](https://git.io/qpl-bib))